### PR TITLE
KtsExec task depends only on host.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Add missing sources jar, required by JCenter
   - Change `KtsExec` `script` param type to `RegularFileProperty` (#7)
   - Skip task execution if no `script` param was provided (#8)
+  - `KtsExec` task depends only on host dependency (#9)
 
 ### [1.0.0] - 2019-03-24
   - Initial implementation

--- a/host/build.gradle.kts
+++ b/host/build.gradle.kts
@@ -14,9 +14,9 @@ group = commonGroup
 version = commonVersion
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-scripting-jvm-host-embeddable:${Versions.kotlin}")
-    implementation("org.jetbrains.kotlin:kotlin-scripting-common:${Versions.kotlin}")
-    implementation("org.jetbrains.kotlin:kotlin-scripting-jvm:${Versions.kotlin}")
+    api("org.jetbrains.kotlin:kotlin-scripting-jvm-host-embeddable:${Versions.kotlin}")
+    api("org.jetbrains.kotlin:kotlin-scripting-common:${Versions.kotlin}")
+    api("org.jetbrains.kotlin:kotlin-scripting-jvm:${Versions.kotlin}")
 }
 
 tasks.register<Jar>("sourcesJar") {

--- a/task/src/main/kotlin/by/egorr/gradle/ktsexec/KtsExec.kt
+++ b/task/src/main/kotlin/by/egorr/gradle/ktsexec/KtsExec.kt
@@ -10,7 +10,6 @@ import java.io.IOException
 
 const val KTS_EXEC_CONFIGURATION_NAME = "ktsExecConfiguration"
 private const val HOST_VERSION = "1.1.0-SNAPSHOT"
-private const val KOTLIN_VERSION = "1.3.21"
 
 @Suppress("UnstableApiUsage")
 open class KtsExec : DefaultTask() {
@@ -21,18 +20,6 @@ open class KtsExec : DefaultTask() {
     init {
         project.configurations.maybeCreate(KTS_EXEC_CONFIGURATION_NAME)
         with(project.dependencies) {
-            add(
-                KTS_EXEC_CONFIGURATION_NAME,
-                "org.jetbrains.kotlin:kotlin-scripting-jvm-host-embeddable:$KOTLIN_VERSION"
-            )
-            add(
-                KTS_EXEC_CONFIGURATION_NAME,
-                "org.jetbrains.kotlin:kotlin-scripting-jvm:$KOTLIN_VERSION"
-            )
-            add(
-                KTS_EXEC_CONFIGURATION_NAME,
-                "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
-            )
             add(
                 KTS_EXEC_CONFIGURATION_NAME,
                 "by.egorr.gradle:ktsexec-host:$HOST_VERSION"


### PR DESCRIPTION
Host exposes all required dependencies.

Closes #9 